### PR TITLE
Fix: Add missing CSS link for Tailwind styles in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RetroNode</title>
+    <link rel="stylesheet" href="css/output.css">
     <!-- Font Awesome (or your preferred icon library) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
The front page game grid was not displaying correctly because `index.html` was missing a link to the compiled Tailwind CSS file (`public/css/output.css`).

This change adds the required stylesheet link to `index.html`, ensuring that Tailwind CSS classes, including those for the grid layout, are applied correctly. This brings its styling mechanism in line with `platforms.html`, which was rendering correctly.