### PR TITLE
Fix: Ensure #gamesGrid displays as a grid

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -54,3 +54,8 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 .modal-header {
   @apply border-b border-border;
 }
+
+/* Ensure #gamesGrid is always display: grid */
+#gamesGrid {
+  display: grid !important;
+}


### PR DESCRIPTION
The games grid was not displaying correctly (items were stacking instead of forming a grid), despite having the correct Tailwind utility classes. Browser computed styles showed 'display: block;' for #gamesGrid.

This commit adds a specific CSS rule:
  #gamesGrid { display: grid !important; }
to src/css/main.css to ensure it overrides any conflicting styles that were forcing a block display.

This should restore the intended grid layout for game cards.