### PR TITLE
Fix: Force #gamesGrid to display:grid via inline style in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <!-- Any other head elements like favicons -->
     <!-- CSS will be handled by Vite through main.js import -->
+   <style>
+     #gamesGrid {
+       display: grid !important;
+     }
+   </style>
 </head>
 <body>
     <!-- Your existing body structure from the old public/index.html -->


### PR DESCRIPTION
To address the persistent issue where the #gamesGrid was not rendering as a grid (computed style was 'display: block;'), I've added a <style> block directly in the <head>
of index.html:

<style>
  #gamesGrid {
    display: grid !important;
  }
</style>

This ensures the rule has high priority and is applied directly to the document, overriding other potential sources that might have been causing 'display: block'. This is a more direct approach after attempts to fix it via external CSS (imported via JS) were not successful.