### PR TITLE
Fix: Prevent game card image container from shrinking and cleanup styles

### DIFF
--- a/public/css/retro-theme.css
+++ b/public/css/retro-theme.css
@@ -132,6 +132,7 @@ body {
   height: 7rem; /* Added */
   position: relative; /* Ensured */
   overflow: hidden; /* Ensured */
+  flex-shrink: 0;       /* Add this to prevent shrinking */
 }
 
 .game-card-content {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -569,7 +569,7 @@ function renderGameCards(games, gamesGrid, platforms) {
     
     card.innerHTML = `
       <h3 class="game-card-title font-heading text-sm truncate" title="${game.title || 'No title'}">${game.title || 'No title'}</h3>
-      <div class="game-card-image" style="position: relative;">
+      <div class="game-card-image">
         <img src="${imageUrl}" 
              alt="${game.title || 'No title'}" 
              class="absolute inset-0 w-full h-full object-cover"


### PR DESCRIPTION
This commit addresses an issue where images might not be showing on game cards after recent resizing efforts.

Changes:
- In public/css/retro-theme.css:
  - Added `flex-shrink: 0;` to the `.game-card-image` rule to prevent it from shrinking within the flex column of `.game-card`.
  - Ensured `position: relative;` is set on `.game-card-image` via CSS.
- In src/js/app.js (renderGameCards):
  - Removed the redundant inline `style="position: relative;"` from the `.game-card-image` div, as this is now handled by the stylesheet.

These changes should improve the robustness of the card image display.