### PR TITLE
Fix: Correct game card layout to ensure all sections are visible

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -88,10 +88,8 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 /* No specific CSS needed here if JS handles it sufficiently with Tailwind. */
 
 .game-card-image {
-  @apply relative w-full bg-dark; /* Aspect ratio will be controlled by padding-top hack or specific height */
-  padding-top: 133.33%; /* Aspect ratio for typical game covers (e.g., 3:4 like SNES boxes, or DVD cases) */
-                               /* For 8rem max-width card, if height was 10rem, this would be 125% */
-                               /* For a responsive square image, it would be 100% */
+  @apply relative overflow-hidden h-28 bg-dark; /* h-28 is 7rem. bg-dark as a fallback if image fails */
+  /* The inner <img> is styled with 'absolute inset-0 w-full h-full object-cover' */
 }
 
 .game-card-image img {


### PR DESCRIPTION
This commit addresses a layout issue on game cards where the game image was taking up the entire card space, hiding the description and action buttons (edit, delete, launch).

The CSS for `.game-card-image` in `src/css/main.css` has been modified to use an explicit height (h-28 / 7rem) instead of padding-top for aspect ratio. This ensures the image container has a fixed size within the flex layout of the `.game-card`.

Combined with `flex-grow: 1` on the description area, this change ensures that the title, image, description, and action buttons are all allocated space and are visible on the game card.