### PR TITLE
Fix: Correct game card layout for 9:16 image aspect and button visibi…

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -68,12 +68,11 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 
 /* Game Card Styles (Adapted from retro-theme.css and new requirements) */
 .game-card {
-  @apply bg-card rounded-lg overflow-hidden shadow-md; /* Use theme variables via @apply */
-  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
-  display: flex;
-  flex-direction: column;
-  position: relative; /* For absolute positioning of image or actions if needed */
-  border: 1px solid var(--color-border); /* Adding a subtle border */
+  @apply bg-card rounded-lg shadow-xl border border-border overflow-hidden flex flex-col h-full;
+  /* h-full assumes parent grid/container defines height.
+     flex flex-col is critical. overflow-hidden is standard. */
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out; /* Keep existing transitions */
+  position: relative; /* Keep for potential absolute children if any */
 }
 
 .game-card:hover {
@@ -82,14 +81,12 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 }
 
 /* .game-card-title is mostly handled by Tailwind classes in app.js (font-heading, text-sm, truncate) */
-/* Additional base styling if necessary (e.g., consistent padding/margin if not in JS) */
-/* For platform cards, .game-card-title is used directly in app.js's renderPlatforms */
-/* For game cards, .game-card-title is also used directly in app.js's renderGameCards */
-/* No specific CSS needed here if JS handles it sufficiently with Tailwind. */
 
 .game-card-image {
-  @apply relative overflow-hidden h-28 bg-dark; /* h-28 is 7rem. bg-dark as a fallback if image fails */
-  /* The inner <img> is styled with 'absolute inset-0 w-full h-full object-cover' */
+  @apply relative w-full bg-dark; /* width: 100% is crucial for padding-top aspect ratio */
+  padding-top: 177.77%; /* For a 9:16 aspect ratio (16/9 * 100) */
+  flex-shrink: 0; /* Prevent shrinking */
+  /* bg-dark as a fallback if image fails and img tag doesn't cover */
 }
 
 .game-card-image img {
@@ -97,9 +94,11 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 }
 
 /* .game-card-platform, .game-card-description, etc. are styled with Tailwind in app.js */
+/* The description container itself in app.js should have flex-grow: 1; overflow-y: auto; min-height: 0; */
 
 .game-card-actions {
   @apply p-2 border-t border-border bg-card bg-opacity-50 flex justify-end space-x-2;
+  flex-shrink: 0; /* Ensure it doesn't shrink */
   /* Ensures padding, a top border, themed semi-transparent background,
      and right-aligns buttons with spacing. */
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -789,7 +789,7 @@ function renderGameCards(games, gamesGrid, platforms) {
              class="absolute inset-0 w-full h-full object-cover"
              onerror="this.onerror=null; this.src='${placeholderUrl}';">
       </div>
-      <div class="p-1" style="flex-grow: 1; overflow-y: auto;">
+      <div class="p-1 min-h-0" style="flex-grow: 1; overflow-y: auto;">
         <p class="text-xs text-body-dim truncate mb-1 game-card-platform" title="${platformNames}">${platformNames}</p>
         <p class="text-xs text-body-dim line-clamp-2 mb-1" title="${game.description || ''}">${game.description || 'No description available.'}</p>
       </div>


### PR DESCRIPTION
…lity

This commit addresses your feedback regarding game card layout issues:
- Game card images were not displaying with the desired 9:16 portrait aspect ratio.
- Action buttons (edit, delete, launch) were not visible.

Changes made:
- In `src/css/main.css`:
    - `.game-card` is now `h-full` to better adapt to parent grid cell heights.
    - `.game-card-image` now uses `padding-top: 177.77%` to enforce a 9:16 aspect ratio and `flex-shrink: 0`. Fixed height has been removed.
    - `.game-card-actions` includes `flex-shrink: 0`.
- In `src/js/app.js` (`renderGameCards` function):
    - The `div` containing the game description now includes the `min-h-0` Tailwind class to ensure correct behavior within the flex column, allowing it to shrink and enable scrolling if necessary.

These changes ensure the image has the correct portrait aspect ratio, and the flex layout correctly allocates space for the title, image, scrollable description, and the action buttons, making all sections visible and functional.