### PR TITLE
Fix: Adjust game card image aspect ratio to ensure button visibility

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -84,7 +84,7 @@ h1, h2, h3, h4, h5, h6, .font-heading { /* Added .font-heading for flexibility *
 
 .game-card-image {
   @apply relative w-full bg-dark; /* width: 100% is crucial for padding-top aspect ratio */
-  padding-top: 177.77%; /* For a 9:16 aspect ratio (16/9 * 100) */
+  padding-top: 133.33%; /* Changed to ~3:4 aspect ratio */
   flex-shrink: 0; /* Prevent shrinking */
   /* bg-dark as a fallback if image fails and img tag doesn't cover */
 }


### PR DESCRIPTION
This commit addresses an issue where action buttons (edit, delete, launch) on game cards were not visible. This was likely due to the previous 9:16 image aspect ratio consuming too much vertical space within the card, causing the action buttons to be clipped by the card's `overflow: hidden` property.

The `padding-top` for the `.game-card-image` class in `src/css/main.css` has been changed from `177.77%` (9:16) to `133.33%` (~3:4). This results in a shorter image area, providing more vertical space for the title, description, and crucially, the action buttons.

Other flex properties on the card and its children (including `flex-grow: 1` and `min-h-0` on the description area, and `flex-shrink: 0` on the image and actions bar) remain in place to ensure a robust flex layout. This change should make the action buttons visible and functional.